### PR TITLE
Fix `tokite:ridgepole:install` error at first time

### DIFF
--- a/lib/tasks/tokite.rake
+++ b/lib/tasks/tokite.rake
@@ -26,13 +26,14 @@ namespace :tokite do
     desc "Install schema"
     task :install do
       tokite_schema_dir = app_path("schema/tokite")
-      mkdir(tokite_schema_dir) unless Dir.exist?(tokite_schema_dir)
+      mkdir_p(tokite_schema_dir) unless Dir.exist?(tokite_schema_dir)
 
       schema_dir = app_path("schema")
-      mkdir(schema_dir) unless Dir.exist?(schema_dir)
+      mkdir_p(schema_dir) unless Dir.exist?(schema_dir)
 
       Dir.glob("#{engine_path("schema")}/*").each do |src_path|
         basename = File.basename(src_path)
+        next if basename == 'tokite'
         if File.exist?(File.join(tokite_schema_dir, basename))
           puts "Skip install schema #{src_path}"
         else


### PR DESCRIPTION
```before
$ ./bin/rails tokite:ridgepole:install
mkdir -p /Users/sugi.kohei/develop/etikot/schema/tokite
Install schema /Users/sugi.kohei/develop/tokite/schema/Schemafile
"/Users/sugi.kohei/develop/tokite/schema/Schemafile"
"/Users/sugi.kohei/develop/etikot/schema/tokite"
cp /Users/sugi.kohei/develop/tokite/schema/Schemafile /Users/sugi.kohei/develop/etikot/schema/tokite
cp /Users/sugi.kohei/develop/tokite/schema/Schemafile /Users/sugi.kohei/develop/etikot/schema
Install schema /Users/sugi.kohei/develop/tokite/schema/tokite
"/Users/sugi.kohei/develop/tokite/schema/tokite"
"/Users/sugi.kohei/develop/etikot/schema/tokite"
cp /Users/sugi.kohei/develop/tokite/schema/tokite /Users/sugi.kohei/develop/etikot/schema/tokite
rails aborted!
Errno::EISDIR: Is a directory - read
/Users/sugi.kohei/develop/tokite/lib/tasks/tokite.rake:43:in `block (4 levels) in <top (required)>'
/Users/sugi.kohei/develop/tokite/lib/tasks/tokite.rake:34:in `each'
/Users/sugi.kohei/develop/tokite/lib/tasks/tokite.rake:34:in `block (3 levels) in <top (required)>'
/Users/sugi.kohei/develop/etikot/bin/rails:9:in `require'
/Users/sugi.kohei/develop/etikot/bin/rails:9:in `<top (required)>'
/Users/sugi.kohei/develop/etikot/bin/spring:15:in `<top (required)>'
./bin/rails:3:in `load'
./bin/rails:3:in `<main>'
Tasks: TOP => tokite:ridgepole:install
(See full trace by running task with --trace)
```

```after
$ ./bin/rails tokite:ridgepole:install
mkdir -p /Users/sugi.kohei/develop/etikot/schema/tokite
Install schema /Users/sugi.kohei/develop/tokite/schema/Schemafile
cp /Users/sugi.kohei/develop/tokite/schema/Schemafile /Users/sugi.kohei/develop/etikot/schema/tokite
cp /Users/sugi.kohei/develop/tokite/schema/Schemafile /Users/sugi.kohei/develop/etikot/schema
Install schema /Users/sugi.kohei/develop/tokite/schema/tokite_repositories.schema
cp /Users/sugi.kohei/develop/tokite/schema/tokite_repositories.schema /Users/sugi.kohei/develop/etikot/schema/tokite
cp /Users/sugi.kohei/develop/tokite/schema/tokite_repositories.schema /Users/sugi.kohei/develop/etikot/schema
Install schema /Users/sugi.kohei/develop/tokite/schema/tokite_rules.schema
cp /Users/sugi.kohei/develop/tokite/schema/tokite_rules.schema /Users/sugi.kohei/develop/etikot/schema/tokite
cp /Users/sugi.kohei/develop/tokite/schema/tokite_rules.schema /Users/sugi.kohei/develop/etikot/schema
Install schema /Users/sugi.kohei/develop/tokite/schema/tokite_secure_user_tokens.schema
cp /Users/sugi.kohei/develop/tokite/schema/tokite_secure_user_tokens.schema /Users/sugi.kohei/develop/etikot/schema/tokite
cp /Users/sugi.kohei/develop/tokite/schema/tokite_secure_user_tokens.schema /Users/sugi.kohei/develop/etikot/schema
Install schema /Users/sugi.kohei/develop/tokite/schema/tokite_users.schema
cp /Users/sugi.kohei/develop/tokite/schema/tokite_users.schema /Users/sugi.kohei/develop/etikot/schema/tokite
cp /Users/sugi.kohei/develop/tokite/schema/tokite_users.schema /Users/sugi.kohei/develop/etikot/schema
```